### PR TITLE
no activejdbc-instrumentation execution

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,14 +128,6 @@
                 <groupId>org.javalite</groupId>
                 <artifactId>activejdbc-instrumentation</artifactId>
                 <version>1.4.9</version>
-                <executions>
-                    <execution>
-                        <phase>process-classes</phase>
-                        <goals>
-                            <goal>instrument</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>org.eclipse.jetty</groupId>


### PR DESCRIPTION
activejdbc process-classes instrument disabled due to jetty-instrumentation conflict
now web-tests work! :-)
